### PR TITLE
Update delete command to use split list indexing

### DIFF
--- a/src/main/java/scrolls/elder/logic/commands/DeleteCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/DeleteCommand.java
@@ -10,6 +10,7 @@ import scrolls.elder.logic.Messages;
 import scrolls.elder.logic.commands.exceptions.CommandException;
 import scrolls.elder.model.Model;
 import scrolls.elder.model.person.Person;
+import scrolls.elder.model.person.Role;
 
 /**
  * Deletes a person identified using its displayed index from the address book.
@@ -31,22 +32,33 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD_REMOVE + " 1";
 
 
-
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_PERSON_ERROR = "Unable to delete contact: ";
     public static final String MESSAGE_CONFIRM_DELETE =
             "Valid contact inputted. Are you sure you want to delete this contact?";
+    public static final String MESSAGE_NO_ROLE = "Role must be specified when editing a person.";
 
     private final Index targetIndex;
+    private final Role role;
 
-    public DeleteCommand(Index targetIndex) {
+    /**
+     * Creates a DeleteCommand to delete the person at the specified {@code targetIndex}.
+     */
+    public DeleteCommand(Index targetIndex, Role role) {
         this.targetIndex = targetIndex;
+        this.role = role;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+
+        List<Person> lastShownList;
+        if (role.isVolunteer()) {
+            lastShownList = model.getFilteredVolunteerList();
+        } else {
+            lastShownList = model.getFilteredBefriendeeList();
+        }
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -82,6 +94,7 @@ public class DeleteCommand extends Command {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetIndex", targetIndex)
+                .add("role", role)
                 .toString();
     }
 }

--- a/src/main/java/scrolls/elder/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/scrolls/elder/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,7 @@
 package scrolls.elder.logic.parser;
 
 import static scrolls.elder.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static scrolls.elder.logic.parser.CliSyntax.PREFIX_ROLE;
 
 import scrolls.elder.commons.core.index.Index;
 import scrolls.elder.logic.commands.DeleteCommand;
@@ -14,12 +15,20 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ROLE);
+            Index index;
+            try {
+                index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            } catch (ParseException pe) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE),
+                        pe);
+            }
+            return new DeleteCommand(index, ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get()));
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/scrolls/elder/logic/LogicManagerTest.java
+++ b/src/test/java/scrolls/elder/logic/LogicManagerTest.java
@@ -56,7 +56,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "delete 9 r/volunteer";
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandException(deleteCommand, expectedMessage);

--- a/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
@@ -15,6 +15,7 @@ import scrolls.elder.model.Model;
 import scrolls.elder.model.ModelManager;
 import scrolls.elder.model.UserPrefs;
 import scrolls.elder.model.person.Person;
+import scrolls.elder.model.person.Role;
 import scrolls.elder.testutil.TypicalIndexes;
 import scrolls.elder.testutil.TypicalPersons;
 
@@ -25,12 +26,14 @@ import scrolls.elder.testutil.TypicalPersons;
  */
 public class DeleteCommandTest {
 
+    private static final String ROLE_STRING = "volunteer";
+    private static final Role ROLE = new Role(ROLE_STRING);
     private Model model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON);
+        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -43,8 +46,8 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVolunteerList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE);
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandFailure(deleteCommand, model, expectedMessage);
@@ -54,8 +57,8 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, TypicalIndexes.INDEX_SECOND_PERSON);
 
-        Person personToDelete = model.getFilteredPersonList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
+        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -75,13 +78,14 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE);
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
-    /* To fix test case so that it does not pollute JSON data
+
+    /* TODO: To be implemented once paired contacts are updated to use ID
     @Test
     public void execute_personPaired_throwsCommandException() {
         Person personToDelete = model.getFilteredPersonList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
@@ -95,14 +99,14 @@ public class DeleteCommandTest {
     */
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -118,8 +122,10 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, ROLE);
+        String expected =
+                String.format("%s{targetIndex=%s, role=%s}", DeleteCommand.class.getCanonicalName(), targetIndex,
+                        ROLE_STRING);
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/scrolls/elder/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/scrolls/elder/logic/parser/AddressBookParserTest.java
@@ -21,6 +21,7 @@ import scrolls.elder.logic.commands.ListCommand;
 import scrolls.elder.logic.parser.exceptions.ParseException;
 import scrolls.elder.model.person.NameContainsKeywordsPredicate;
 import scrolls.elder.model.person.Person;
+import scrolls.elder.model.person.Role;
 import scrolls.elder.testutil.Assert;
 import scrolls.elder.testutil.EditPersonDescriptorBuilder;
 import scrolls.elder.testutil.PersonBuilder;
@@ -29,6 +30,7 @@ import scrolls.elder.testutil.TypicalIndexes;
 
 public class AddressBookParserTest {
 
+    private static final String ROLE_STRING = "volunteer";
     private final AddressBookParser parser = new AddressBookParser();
 
     @Test
@@ -46,30 +48,34 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete1() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD_DELETE + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+        String userInput = String.format("%s %d r/%s", DeleteCommand.COMMAND_WORD_DELETE,
+                TypicalIndexes.INDEX_FIRST_PERSON.getOneBased(), ROLE_STRING);
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(userInput);
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, new Role(ROLE_STRING)), command);
     }
 
     @Test
     public void parseCommand_delete2() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD_DEL + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+        String userInput = String.format("%s %d r/%s", DeleteCommand.COMMAND_WORD_DEL,
+                TypicalIndexes.INDEX_FIRST_PERSON.getOneBased(), ROLE_STRING);
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(userInput);
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, new Role(ROLE_STRING)), command);
     }
 
     @Test
     public void parseCommand_delete3() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD_RM + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+        String userInput = String.format("%s %d r/%s", DeleteCommand.COMMAND_WORD_RM,
+                TypicalIndexes.INDEX_FIRST_PERSON.getOneBased(), ROLE_STRING);
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(userInput);
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, new Role(ROLE_STRING)), command);
     }
 
     @Test
     public void parseCommand_delete4() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD_REMOVE + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+        String userInput = String.format("%s %d r/%s", DeleteCommand.COMMAND_WORD_REMOVE,
+                TypicalIndexes.INDEX_FIRST_PERSON.getOneBased(), ROLE_STRING);
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(userInput);
+        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, new Role(ROLE_STRING)), command);
     }
 
     @Test

--- a/src/test/java/scrolls/elder/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/scrolls/elder/logic/parser/DeleteCommandParserTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import scrolls.elder.logic.Messages;
 import scrolls.elder.logic.commands.DeleteCommand;
+import scrolls.elder.model.person.Role;
 import scrolls.elder.testutil.TypicalIndexes;
 
 /**
@@ -18,11 +19,13 @@ import scrolls.elder.testutil.TypicalIndexes;
  */
 public class DeleteCommandParserTest {
 
+    private static final String ROLE_STRING = "volunteer";
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1 r/" + ROLE_STRING,
+                new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, new Role(ROLE_STRING)));
     }
 
     @Test


### PR DESCRIPTION
- The delete command now has the format `delete <index> r/<role>`
- This accomodates the use of split list indexing, where each list has independent indexes