### PR TITLE
Fix 3 testcases in EditCommandTest

### DIFF
--- a/src/main/java/scrolls/elder/logic/commands/EditCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/EditCommand.java
@@ -117,7 +117,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/test/java/scrolls/elder/logic/commands/EditCommandTest.java
+++ b/src/test/java/scrolls/elder/logic/commands/EditCommandTest.java
@@ -13,6 +13,8 @@ import scrolls.elder.model.Model;
 import scrolls.elder.model.ModelManager;
 import scrolls.elder.model.UserPrefs;
 import scrolls.elder.model.person.Person;
+import scrolls.elder.model.person.Role;
+import scrolls.elder.model.person.Volunteer;
 import scrolls.elder.testutil.EditPersonDescriptorBuilder;
 import scrolls.elder.testutil.PersonBuilder;
 import scrolls.elder.testutil.TypicalIndexes;
@@ -116,7 +118,7 @@ public class EditCommandTest {
 
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditCommand.EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build();
+                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).withRole("befriendee").build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -136,7 +138,7 @@ public class EditCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build());
+                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).withRole("volunteer").build());
 
         CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }


### PR DESCRIPTION
4 testcases remaining:
- execute_allFieldsSpecifiedUnfilteredList_success()
- execute_filteredList_success()
- execute_noFieldSpecifiedUnfilteredList_success()
- execute_noFieldSpecifiedUnfilteredList_success()