### PR TITLE
Fix test cases for delete command

### DIFF
--- a/src/main/java/scrolls/elder/logic/commands/DeleteCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package scrolls.elder.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static scrolls.elder.logic.parser.CliSyntax.PREFIX_ROLE;
 
 import java.util.List;
 
@@ -23,13 +24,21 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD_REMOVE = "remove";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD_DELETE
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD_DELETE + " 1"
+            + ": Deletes the person identified by the index number used in the displayed person list and their type.\n"
+            + "Parameters: INDEX (must be a positive integer), TYPE (volunteer or befriendee)\n"
+            + "Example: " + COMMAND_WORD_DELETE + " 1 "
+            + PREFIX_ROLE
+            + "{VOLUNTEER or BEFRIENDEE}\n"
             + "Alternatively, you can also delete a person using the following commands as well.\n"
-            + "Example: " + COMMAND_WORD_DEL + " 1"
-            + "Example: " + COMMAND_WORD_RM + " 1"
-            + "Example: " + COMMAND_WORD_REMOVE + " 1";
+            + "Example: " + COMMAND_WORD_DEL + " 1\n"
+            + PREFIX_ROLE
+            + "{VOLUNTEER or BEFRIENDEE}\n"
+            + "Example: " + COMMAND_WORD_RM + " 1\n"
+            + PREFIX_ROLE
+            + "{VOLUNTEER or BEFRIENDEE}\n"
+            + "Example: " + COMMAND_WORD_REMOVE + " 1"
+            + PREFIX_ROLE
+            + "{VOLUNTEER or BEFRIENDEE}\n";
 
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/scrolls/elder/logic/commands/UnpairCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/UnpairCommand.java
@@ -27,7 +27,7 @@ import scrolls.elder.model.tag.Tag;
 public class UnpairCommand extends Command {
     public static final String COMMAND_WORD = "unpair";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Unpairs a volunteer and a befriendee specified"
+            COMMAND_WORD + ": Unpairs a volunteer and a befriendee specified "
                     + "by their index numbers used in the displayed person list.\n"
                     + "Parameters: INDEX1 INDEX2 (both must be a positive integers)\n"
                     + "Example: " + COMMAND_WORD + " 1 2";

--- a/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
@@ -85,18 +85,36 @@ public class DeleteCommandTest {
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
-    /* TODO: To be implemented once paired contacts are updated to use ID
     @Test
     public void execute_personPaired_throwsCommandException() {
-        Person personToDelete = model.getFilteredPersonList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
-        personToDelete.setPairedWith(Optional.of(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased()));
+        showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
+
+        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
 
         String expectedMessage =
-                DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_CONTACT_PAIRED_BEFORE_DELETE);
+                DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_CONTACT_PAIRED_BEFORE_DELETE;
+
         assertCommandFailure(deleteCommand, model, expectedMessage);
     }
-    */
+
+    @Test
+    public void execute_personNotPaired_success() {
+        showPersonAtIndex(model, TypicalIndexes.INDEX_SECOND_PERSON);
+
+        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
     @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);

--- a/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/scrolls/elder/logic/commands/DeleteCommandTest.java
@@ -26,14 +26,16 @@ import scrolls.elder.testutil.TypicalPersons;
  */
 public class DeleteCommandTest {
 
-    private static final String ROLE_STRING = "volunteer";
-    private static final Role ROLE = new Role(ROLE_STRING);
+    private static final String ROLE_STRING_VOLUNTEER = "volunteer";
+    private static final String ROLE_STRING_BEFRIENDEE = "befriendee";
+    private static final Role ROLE_VOLUNTEER = new Role(ROLE_STRING_VOLUNTEER);
+    private static final Role ROLE_BEFRIENDEE = new Role(ROLE_STRING_BEFRIENDEE);
     private Model model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE_VOLUNTEER);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -47,7 +49,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredVolunteerList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE_VOLUNTEER);
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
         assertCommandFailure(deleteCommand, model, expectedMessage);
@@ -58,7 +60,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, TypicalIndexes.INDEX_SECOND_PERSON);
 
         Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE_VOLUNTEER);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -78,7 +80,7 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, ROLE_VOLUNTEER);
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
@@ -87,10 +89,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_personPaired_throwsCommandException() {
-        showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
-
-        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE_VOLUNTEER);
 
         String expectedMessage =
                 DeleteCommand.MESSAGE_DELETE_PERSON_ERROR + Messages.MESSAGE_CONTACT_PAIRED_BEFORE_DELETE;
@@ -100,31 +99,29 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_personNotPaired_success() {
-        showPersonAtIndex(model, TypicalIndexes.INDEX_SECOND_PERSON);
-
-        Person personToDelete = model.getFilteredVolunteerList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+        Person personToDelete =
+                model.getFilteredBefriendeeList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE_BEFRIENDEE);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE_VOLUNTEER);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON, ROLE_VOLUNTEER);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON, ROLE_VOLUNTEER);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -140,10 +137,10 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, ROLE);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, ROLE_VOLUNTEER);
         String expected =
                 String.format("%s{targetIndex=%s, role=%s}", DeleteCommand.class.getCanonicalName(), targetIndex,
-                        ROLE_STRING);
+                        ROLE_STRING_VOLUNTEER);
         assertEquals(expected, deleteCommand.toString());
     }
 


### PR DESCRIPTION
The test case fixed checks if the person is paired and throws the
correct exception if paired.

A test case is added, which checks if the person is paired and successfully deletes
the person from the addressbook if not paired.

The message usage variable for delete command was fixed to reflect the
addtion of the new role parameter added.

Closes #51 