### PR TITLE
Fix minor bug in logadd and logedit for latest log

### DIFF
--- a/src/main/java/scrolls/elder/logic/commands/LogAddCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/LogAddCommand.java
@@ -147,7 +147,7 @@ public class LogAddCommand extends Command {
             Log currentLatest = logStore.getLogById(person.getLatestLogId().get());
             Date latestLogDate = currentLatest.getStartDate();
 
-            if (!toAddDate.before(latestLogDate)) {
+            if (toAddDate.before(latestLogDate)) {
                 return currentLatest.getLogId();
             } else {
                 return toAddId;

--- a/src/main/java/scrolls/elder/logic/commands/LogEditCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/LogEditCommand.java
@@ -170,7 +170,7 @@ public class LogEditCommand extends Command {
             Log currentLatest = logStore.getLogById(person.getLatestLogId().get());
             Date latestLogDate = currentLatest.getStartDate();
 
-            if (!editedDate.before(latestLogDate)) {
+            if (editedDate.before(latestLogDate)) {
                 return currentLatest.getLogId();
             } else {
                 return toAddId;


### PR DESCRIPTION
- There was a bug in the getLatestLogId methods in logadd and logedit where the if clause had the negated clause, causing the least recent logId to be returned