### PR TITLE
Fix AOOB exception when parsing pair, unpair and logadd inputs

### DIFF
--- a/src/main/java/scrolls/elder/logic/parser/LogAddCommandParser.java
+++ b/src/main/java/scrolls/elder/logic/parser/LogAddCommandParser.java
@@ -51,8 +51,8 @@ public class LogAddCommandParser implements Parser<LogAddCommand> {
         try {
             index1 = ParserUtil.parseIndex(pairIndexes[0]);
             index2 = ParserUtil.parseIndex(pairIndexes[1]);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogAddCommand.MESSAGE_USAGE), pe);
+        } catch (ParseException | ArrayIndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LogAddCommand.MESSAGE_USAGE), e);
         }
 
         String title = argMultimap.getValue(CliSyntax.PREFIX_TITLE).get().trim();

--- a/src/main/java/scrolls/elder/logic/parser/PairCommandParser.java
+++ b/src/main/java/scrolls/elder/logic/parser/PairCommandParser.java
@@ -26,8 +26,8 @@ public class PairCommandParser implements Parser<PairCommand> {
         try {
             index1 = ParserUtil.parseIndex(pairIndexes[0]);
             index2 = ParserUtil.parseIndex(pairIndexes[1]);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PairCommand.MESSAGE_USAGE), pe);
+        } catch (ParseException | ArrayIndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PairCommand.MESSAGE_USAGE), e);
         }
 
         return new PairCommand(index1, index2);

--- a/src/main/java/scrolls/elder/logic/parser/UnpairCommandParser.java
+++ b/src/main/java/scrolls/elder/logic/parser/UnpairCommandParser.java
@@ -26,8 +26,8 @@ public class UnpairCommandParser implements Parser<UnpairCommand> {
         try {
             index1 = ParserUtil.parseIndex(pairIndexes[0]);
             index2 = ParserUtil.parseIndex(pairIndexes[1]);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnpairCommand.MESSAGE_USAGE), pe);
+        } catch (ParseException | ArrayIndexOutOfBoundsException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnpairCommand.MESSAGE_USAGE), e);
         }
 
         return new UnpairCommand(index1, index2);


### PR DESCRIPTION
Edit PairCommand, UnpairCommand and LogAddCommand parsers to catch ArrayOutOfBounds exception when retrieving the indexes in the input

Closes #189