### PR TITLE
Fix exception messages displaying wrong information

### DIFF
--- a/src/main/java/scrolls/elder/logic/commands/LogAddCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/LogAddCommand.java
@@ -49,7 +49,7 @@ public class LogAddCommand extends Command {
         + PREFIX_REMARKS + "was a good session ";
 
     public static final String MESSAGE_SUCCESS = "New log added!";
-    public static final String MESSAGE_NEGATIVE_DURATION = "Duration cannot be negative.";
+    public static final String MESSAGE_NEGATIVE_DURATION = "Duration must be positive.";
     public static final String MESSAGE_PERSONS_NOT_PAIRED = "The volunteer and befriendee are not paired.";
 
     /**

--- a/src/main/java/scrolls/elder/logic/commands/LogEditCommand.java
+++ b/src/main/java/scrolls/elder/logic/commands/LogEditCommand.java
@@ -54,7 +54,7 @@ public class LogEditCommand extends Command {
 
     public static final String MESSAGE_EDIT_LOG_SUCCESS = "Edited Log successfully: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_NEGATIVE_DURATION = "Duration cannot be negative.";
+    public static final String MESSAGE_NEGATIVE_DURATION = "Duration must be positive.";
 
     private final Index index;
     private final EditLogDescriptor editLogDescriptor;

--- a/src/main/java/scrolls/elder/logic/parser/ParserUtil.java
+++ b/src/main/java/scrolls/elder/logic/parser/ParserUtil.java
@@ -173,7 +173,7 @@ public class ParserUtil {
         try {
             return Integer.parseInt(trimmedNum);
         } catch (NumberFormatException e) {
-            throw new ParseException("Invalid number format. Expected a number.", e);
+            throw new ParseException("Invalid number format. Expected an integer.", e);
         }
     }
 }

--- a/src/test/java/scrolls/elder/logic/parser/LogAddCommandParserTest.java
+++ b/src/test/java/scrolls/elder/logic/parser/LogAddCommandParserTest.java
@@ -52,7 +52,7 @@ class LogAddCommandParserTest {
     @Test
     public void parse_invalidDurationFormat_throwsParseException() {
         assertParseFailure(parser, "1 2 t/Movies s/2024-03-07 d/Two r/Good",
-                "Invalid number format. Expected a number.");
+                "Invalid number format. Expected an integer.");
     }
 
     @Test

--- a/src/test/java/scrolls/elder/logic/parser/LogEditCommandParserTest.java
+++ b/src/test/java/scrolls/elder/logic/parser/LogEditCommandParserTest.java
@@ -80,7 +80,7 @@ class LogEditCommandParserTest {
     @Test
     public void parse_invalidDurationFormat_throwsParseException() {
         assertParseFailure(parser, "1 t/Icebreaker s/2024-04-08 d/Two r/Was okay.",
-                "Invalid number format. Expected a number.");
+                "Invalid number format. Expected an integer.");
     }
     @Test
     public void parse_invalidArgs_throwsParseException() {


### PR DESCRIPTION
- Fix wrong information in exception messages regarding duration in logAdd command.
- Fix wrong information in exception messages regarding duration in logEdit command.

Fixes #206 